### PR TITLE
Replace ES2015 by ES5 syntax

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -40,5 +40,8 @@
     "paper-menu": "PolymerElements/paper-menu#~1.1.1",
     "paper-dropdown-menu": "PolymerElements/paper-dropdown-menu#~1.1.0",
     "paper-input": "PolymerElements/paper-input#~1.0.18"
+  },
+  "resolutions": {
+    "paper-styles": "^1.0.0"
   }
 }

--- a/paper-datatable-card.html
+++ b/paper-datatable-card.html
@@ -395,12 +395,18 @@
 								var done = function(){
 									i++;
 									if(i == 2){
-										var sortedItems = ids.map((id) => items.find((item) => item[this.idProperty] == id));
+										var sortedItems = ids.map(function(id) {
+											return items.find(function(item) {
+												return item[this.idProperty] == id;
+											}.bind(this));
+										}.bind(this));
 										processItems(sortedItems);
 									}
 								}.bind(this);
 
-								var idsInCache = ids.filter((id) => this._cache.has(id));
+								var idsInCache = ids.filter(function(id) {
+									return this._cache.has(id);
+								}.bind(this));
 								if(idsInCache.length){
 									var cacheItems = [];
 									idsInCache.forEach(function(id){
@@ -412,7 +418,9 @@
 									done();
 								}
 
-								var idsNotInCache = ids.filter((id) => !this._cache.has(id));
+								var idsNotInCache = ids.filter(function(id) {
+									return !this._cache.has(id)
+								}.bind(this));
 								if(idsNotInCache.length){
 									this.dataSource.getByIds(idsNotInCache).then(function(newItems){
 										items = items.concat(newItems);

--- a/paper-datatable.html
+++ b/paper-datatable.html
@@ -510,7 +510,7 @@ A [material design implementation of a data table](https://www.google.com/design
 
 				_queryAndSetColumns: function(){
 					var columns = this.queryAllEffectiveChildren('paper-datatable-column');
-					columns.forEach((column) => {
+					columns.forEach(function(column) {
 						if(!column.beenAttached.state.ready){
 							column.parentNodeRef = this;
 							this.async(function(){
@@ -518,8 +518,10 @@ A [material design implementation of a data table](https://www.google.com/design
 								column.beenAttached.ready();
 							});
 						}
-					});
-					this.set('_columns', columns.filter((column) => !column.inactive));
+					}.bind(this));
+					this.set('_columns', columns.filter(function(column) {
+						return !column.inactive;
+					}));
 					this.async(function(){
 						this._applySortedIndicatorsToDOM();
 					});
@@ -564,7 +566,10 @@ A [material design implementation of a data table](https://www.google.com/design
 					var cells = Polymer.dom(this.root).querySelectorAll('.bound-cell');
 					cells.forEach(this._resetCell.bind(this));
 					this.$.rowRepeat.render();
-					Polymer.dom(this.root).querySelectorAll('#cellRepeat').forEach((cr) => cr.render());
+					Polymer.dom(this.root).querySelectorAll('#cellRepeat')
+					.forEach(function(cr) {
+						cr.render();
+					});
 				},
 
 				_resetCell: function(cell){
@@ -587,7 +592,7 @@ A [material design implementation of a data table](https://www.google.com/design
 
 							var cells = Polymer.dom(row).querySelectorAll('.bound-cell');
 
-							cells.forEach((cell) => {
+							cells.forEach(function(cell) {
 
 								if(!cell.dataColumn){
 									console.log(cell);
@@ -645,7 +650,9 @@ A [material design implementation of a data table](https://www.google.com/design
 						//not too happy about this 'hack', but it will have to do for the moment
 						var cells = Polymer.dom(this.root).querySelectorAll('.bound-cell');
 						if(cells.length > 0){
-							cells.forEach((cell) => cell.setAttribute('data-row-key', ''));
+							cells.forEach(function(cell) {
+								cell.setAttribute('data-row-key', '');
+							});
 							this._restructureData();
 						}
 					}
@@ -1085,7 +1092,7 @@ A [material design implementation of a data table](https://www.google.com/design
 						if(this._columns.length > 0){
 
 							var ths = Polymer.dom(this.root).querySelectorAll('th');
-							ths.forEach((th) => {
+							ths.forEach(function(th) {
 								if(th.dataColumn){
 									var column = th.dataColumn;
 									if(th.scrollWidth > th.offsetWidth){


### PR DESCRIPTION
This commit replace some line of code using the arrow functions of
ES2015. The reason is, for now, Safari does not support this feature.
Using a transpiler like Babel and Traceur could fix the issue but it
seems not so easy to make it compatible with others dependencies
(momentjs does not support the transpile step for example) and I think
it's not the responsibility of the "paper-datatable" useres to do this.
The element should be bundled.